### PR TITLE
Added tostring and partially added tonumber

### DIFF
--- a/src/cbaselib.c
+++ b/src/cbaselib.c
@@ -75,6 +75,38 @@ int cosmoB_loadstring(CState *state, int nargs, CValue *args) {
     return 2; // <boolean>, <closure> or <error>
 }
 
+int cosmoB_tostring(CState *state, int nargs, CValue *args) {
+    if (nargs > 1) {
+        cosmoV_error(state, "tostring() expected 1 argument, got %d!", nargs);
+        return 0;
+    }
+
+    cosmoV_pushString(state, cosmoV_toString(state, args[0])->str);
+
+    return 1;
+}
+
+int cosmoB_tonumber(CState *state, int nargs, CValue *args) {
+    if (nargs > 1) {
+        cosmoV_error(state, "tonumber() expected 1 argument, got %d", nargs);
+        return 0;
+    }
+
+    CValue arg = args[0];
+    switch(GET_TYPE(arg)) {
+        case COSMO_TNUMBER:
+            cosmoV_pushNumber(state, cosmoV_readNumber(arg));
+        case COSMO_TBOOLEAN:
+            cosmoV_pushNumber(state, cosmoV_readBoolean(arg) ? 1 : 0);
+        case COSMO_TOBJ:
+            cosmoV_pushNumber(state, 0); // pending __tonumber or similar
+        case COSMO_TNIL:
+            cosmoV_pushNumber(state, 0);
+    }
+
+    return 1;
+}
+
 // ================================================================ [STRING.*] ================================================================
 
 // string.sub
@@ -126,7 +158,9 @@ void cosmoB_loadLibrary(CState *state) {
         "assert",
         "type",
         "pcall",
-        "loadstring"
+        "loadstring",
+        "tostring",
+        "tonumber"
     };
 
     CosmoCFunction baseLib[] = {
@@ -134,7 +168,9 @@ void cosmoB_loadLibrary(CState *state) {
         cosmoB_assert,
         cosmoB_type,
         cosmoB_pcall,
-        cosmoB_loadstring
+        cosmoB_loadstring,
+        cosmoB_tostring,
+        cosmoB_tonumber
     };
 
     int i;

--- a/src/cbaselib.h
+++ b/src/cbaselib.h
@@ -9,6 +9,8 @@ COSMO_API int cosmoB_print(CState *state, int nargs, CValue *args);
 COSMO_API int cosmoB_assert(CState *state, int nargs, CValue *args);
 COSMO_API int cosmoB_type(CState *state, int nargs, CValue *args);
 COSMO_API int cosmoB_pcall(CState *state, int nargs, CValue *args);
+COSMO_API int cosmoB_tostring(CState *state, int nargs, CValue *args);
+COSMO_API int cosmoB_tonumber(CState *state, int nargs, CValue *args);
 
 #define cosmoV_typeError(state, name, expectedTypes, formatStr, ...) \
         cosmoV_error(state, name " expected (" expectedTypes "), got (" formatStr ")!", __VA_ARGS__);


### PR DESCRIPTION
Started doing stuff with Cosmo again... anyway I saw these two functions which I added to the standard library a while ago on my fork and thought I might as well push them and make a pull request. At the time of writing `tonumber` is missing support for objects (pending the addition of more metamethods) and calling it with a number always returns 0 for some reason... no idea why seeing as the code is identical to other value type cases so I suspect internal problems.

This should add two nifty little utility functions. If you have any suggestions or want me to change the code in some way, let me know or you can also make the change yourself.