### PR TITLE
Add optional custom error message to assert

### DIFF
--- a/docs/stdlib.md
+++ b/docs/stdlib.md
@@ -14,7 +14,7 @@ Includes misc. functions. The "junk drawer" of the standard library. Without the
 | tostring     | `(<ANY>)` -> `<string>`                          | Converts the datatype to a `<string>`, if a `<ref>` is passed `__tostring` metamethod is invoked | `tostring(12)` -> `"12"` |
 | error        | `(<string>)`                                     | Throws an error with the passed `<string>`                 | `error("error!")` |
 | pcall        | `(<callable>)` -> `<bool>, <error> or <ANY>`              | Tries a protected call on the passed function, if an error is thrown, `<bool>` will be false and the 2nd result will be the error message | `pcall(error("Hello world!"))` -> `false, "Hello world!"` |
-| assert       | `(<bool>)`                                       | If the passed `<bool>` is false, an error is thrown        | `assert(1 == 1)`  |
+| assert       | `(<bool>, <string>)`                                       | If the passed `<bool>` is false, an error is thrown, optionally uses custom error message        | `assert(1 == 1, "Error Message!")`  |
 | loadstring   | `(<string>)` -> `<boolean>, <function> or <error>` | If the `<string>` compiled successfully, 1st result will be true and the 2nd result will be the newly compiled function. If there was a compiler/lexer error, the 1st result will be false and the 2nd result will be the error | `loadstring("print(\"hi\")")()` |
 > -> means 'returns'
 

--- a/src/cbaselib.c
+++ b/src/cbaselib.c
@@ -30,7 +30,12 @@ int cosmoB_assert(CState *state, int nargs, CValue *args) {
     }
 
     if (!IS_BOOLEAN(args[0]) || (nargs == 2 && !IS_STRING(args[1]))) {
-        cosmoV_typeError(state, "assert()", "<boolean>, <string>", "%s, %s", cosmoV_typeStr(args[0]), cosmoV_typeStr(args[1]));
+        if (nargs == 2) {
+            cosmoV_typeError(state, "assert()", "<boolean>, <string>", "%s, %s", cosmoV_typeStr(args[0]), cosmoV_typeStr(args[1]));
+        }
+        else {
+            cosmoV_typeError(state, "assert()", "<boolean>", "%s", cosmoV_typeStr(args[0]));
+        }
         return 0;
     }
 

--- a/src/cbaselib.c
+++ b/src/cbaselib.c
@@ -24,18 +24,23 @@ int cosmoB_print(CState *state, int nargs, CValue *args) {
 }
 
 int cosmoB_assert(CState *state, int nargs, CValue *args) {
-    if (nargs != 1) {
-        cosmoV_error(state, "assert() expected 1 argument, got %d!", nargs);
+    if (nargs < 1 || nargs > 2) {
+        cosmoV_error(state, "assert() expected 1 or 2 arguments, got %d!", nargs);
         return 0; // nothing pushed onto the stack to return
     }
 
-    if (!IS_BOOLEAN(args[0])) {
-        cosmoV_typeError(state, "assert()", "<boolean>", "%s", cosmoV_typeStr(args[0]));
+    if (!IS_BOOLEAN(args[0]) || (nargs == 2 && !IS_STRING(args[1]))) {
+        cosmoV_typeError(state, "assert()", "<boolean>, <string>", "%s, %s", cosmoV_typeStr(args[0]), cosmoV_typeStr(args[1]));
         return 0;
     }
 
     if (!cosmoV_readBoolean(args[0])) { // expression passed was false, error!
-        cosmoV_error(state, "assert() failed!");
+        if (nargs == 2) {
+            cosmoV_error(state, "%s", cosmoV_readCString(args[1]));
+        }
+        else { // optional custom error message
+            cosmoV_error(state, "%s", "assert() failed!");
+        }
     } // else do nothing :)
 
     return 0;


### PR DESCRIPTION
The user may now provide an optional 2nd argument to `assert`, which is the error message thrown if `assert` evaluates to false (e.g. `assert(1 == 2, "Error")`).